### PR TITLE
Fix deprecation warning

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -60,7 +60,8 @@ export = class Oncall {
                         options: {
                             team: {
                                 usage: 'limit policies to those of a given team',
-                                shortcut: 't'
+                                shortcut: 't',
+                                type: 'string'
                             }
                         }
                     }


### PR DESCRIPTION
This pull request fixes the following deprecation warning:
```
CLI options definitions were upgraded with "type" property (which could be one of "string", "boolean", "multiple"). Below listed plugins do not predefine type for introduced options:
 - Oncall for "team"
```